### PR TITLE
Small imrovements

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -38,7 +38,7 @@ export async function handle({ event, resolve }) {
         email: sanatizeHeader(event, sysConfig.userHttpHeaders.email) || null,
         username: sanatizeHeader(event, sysConfig.userHttpHeaders.username) || null,
         groups: sanatizeHeader(event, sysConfig.userHttpHeaders.groups)
-          .split(/\s*,\s*/)
+          .split(sysConfig.userHttpHeaders.groups_separator || ',')
           .filter(group => !!group),
         isAdmin: sysConfig.admin_userids.includes(userid),
         lang: getConfiguredUserLang(event)

--- a/src/lib/server/authz.ts
+++ b/src/lib/server/authz.ts
@@ -13,7 +13,7 @@ function isUserAllowed(allowRule: AccessRule | undefined, denyRule: AccessRule |
       const condValue = rest.join(':')
       switch (condType.toLowerCase()) {
         case 'user':
-          if (condValue === user.userid) return true
+          if (condValue === user.username) return true
           break
         case 'email':
         case 'mail':

--- a/src/lib/server/sysconfig/index.ts
+++ b/src/lib/server/sysconfig/index.ts
@@ -59,9 +59,10 @@ async function loadConfig(): Promise<Sysconfig> {
     httpcache_ttl: parseInt(env.SERVER_REQUEST_CACHE_TTL as string),
     userHttpHeaders: {
       userid: env.HTTP_HEADER_USERID as string,
-      email: env.HTTP_HEADER_USERNAME as string,
-      username: env.HTTP_HEADER_EMAIL as string,
-      groups: env.HTTP_HEADER_GROUPS as string
+      email: env.HTTP_HEADER_EMAIL as string,
+      username: env.HTTP_HEADER_USERNAME as string,
+      groups: env.HTTP_HEADER_GROUPS as string,
+      groups_separator: env.HTTP_HEADER_GROUPS_SEPARATOR as string
     },
     logLevel: (env.LOG_LEVEL || 'info') as any,
     appInfo: { buildDate: PUBLIC_BUILD_DATE || 'unknown', version: PUBLIC_VERSION || 'edge' }

--- a/src/lib/server/sysconfig/types.d.ts
+++ b/src/lib/server/sysconfig/types.d.ts
@@ -54,6 +54,7 @@ export interface Sysconfig extends FileSysconfig {
     email: string
     username: string
     groups: string
+    groups_separator: string
   }
 
   server_request_timeout: {


### PR DESCRIPTION
Added possibility to set a separator for HTTP groups header (i.e. Authentik uses '|')
Fixed wrong selection of headers into username/email
Switched condition checking for user to look into username instead of uid

P.S. Ideally, `admin_userids` should be `admin_users` and use username too