### PR TITLE
Added `sections` for grouping tiles

### DIFF
--- a/src/lib/server/sysconfig/default.yml
+++ b/src/lib/server/sysconfig/default.yml
@@ -24,35 +24,16 @@ messages:
       <p>Edit the <code>config.yml</code> file to customize your setup <b>:)</b></p>
       <hr style="border-style: dotted">
       <footer style="font-size: 11pt; text-align: right">
-        Find hubleys documentation on 
+        Find hubleys documentation on
         <a href="https://github.com/knrdl/hubleys-dashboard" target="_blank" rel="noopener noreferrer">Github</a>.
       </footer>
     allow: true # show to everyone
 
-tiles:
+tiles: # backwards compatibility. Will create a default section
   - title: Logout
     url: https://example.org/logout/
     logo: authelia # a tile can have a `logo` (image) and an `emoji` (text). Logos have precedence. At least a `logo` or an `emoji` should be present for a tile
     allow: true # show to everybody
-
-  - title: Admin
-    allow: [user:demo1, group:example-group1, email:demo1@example.org] # user must fulfill at least on condition to see tile
-    menu:
-      - title: PiHole
-        url: https://example.org/pihole/
-        logo: pihole
-      - title: Portainer
-        url: https://example.org/portainer/
-        logo: portainer
-      - title: Speedtest
-        url: https://example.org/speedtest/
-        logo: librespeed
-        allow: [group:example-group1] # access to menu items can also be restricted
-
-  - title: Hidden
-    url: https://example.org
-    emoji: Secret
-    allow: false # always hidden
 
   - title: Animals
     allow: true
@@ -76,28 +57,79 @@ tiles:
             emoji: 🐶
             url: https://httpstatusdogs.com/
 
-  - title: Grafana
-    subtitle: Monitoring
-    # logo can be a local file or point to a web image, see README.md section "I need more icons"
-    logo: grafana # or: https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/png/grafana.png
-    url: https://grafana.com/
-    allow: true
-    menu:
-      title: Grafana Dashboards
-      tiles:
-        - title: Dashboard 1
-          emoji: 📈
-          url: https://example.org/dashboard1/
-        - title: Dashboard 2
-          emoji: 📉
-          url: https://example.org/dashboard2/
-        - title: Dashboard 3
-          emoji: 📊
-          url: https://example.org/dashboard3/
-        - title: Dashboard 4
-          emoji: 💹
-          url: https://example.org/dashboard4/
-
   - title: Sverdle
     url: /sverdle/
     allow: true
+
+sections: # divides your tiles into sections
+  - allow: true # show this section to anyone
+    tiles:
+      - title: Logout
+        url: https://example.org/logout/
+        logo: authelia # a tile can have a `logo` (image) and an `emoji` (text). Logos have precedence. At least a `logo` or an `emoji` should be present for a tile
+        #allow: true # Is true by default
+
+      - title: Hidden
+        url: https://example.org
+        emoji: Secret
+        allow: false # always hidden
+
+      - title: Animals
+        allow: true
+        menu: # tiles can have nested menus
+          - title: Cats
+            deny: [group:dog-lovers]
+            menu:
+              - title: Cat1
+                emoji: 🐈
+                url: https://http.cat/
+              - title: Cat2
+                emoji: 🐈
+                url: https://http.cat/
+          - title: Dogs
+            deny: [group:cat-lovers]
+            menu:
+              - title: Dog1
+                emoji: 🐶
+                url: https://httpstatusdogs.com/
+              - title: Dog2
+                emoji: 🐶
+                url: https://httpstatusdogs.com/
+
+      - title: Sverdle
+        url: /sverdle/
+        allow: true
+
+  - title: Admin # section can have titles
+    allow: [user:defaultuser, group:example-group1, email:demo1@example.org] # user must fulfill at least on condition to see tile
+    tiles:
+      - title: PiHole
+        url: https://example.org/pihole/
+        logo: pihole
+      - title: Portainer
+        url: https://example.org/portainer/
+        logo: portainer
+      - title: Grafana
+        subtitle: Monitoring
+        logo: grafana # or: https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/png/grafana.png
+        url: https://grafana.com/
+        deny: [username:notdefaultuser] # username should be `defaultuser`
+        menu:
+          title: Grafana Dashboards
+          tiles:
+            - title: Dashboard 1
+              emoji: 📈
+              url: https://example.org/dashboard1/
+            - title: Dashboard 2
+              emoji: 📉
+              url: https://example.org/dashboard2/
+            - title: Dashboard 3
+              emoji: 📊
+              url: https://example.org/dashboard3/
+            - title: Dashboard 4
+              emoji: 💹
+              url: https://example.org/dashboard4/
+      - title: Speedtest
+        url: https://example.org/speedtest/
+        logo: librespeed
+        allow: [group:example-group1] # access to section items can also be restricted

--- a/src/lib/server/sysconfig/index.ts
+++ b/src/lib/server/sysconfig/index.ts
@@ -24,9 +24,15 @@ function sanatizeFileConfig(config: FileSysconfig) {
       sanatizeTileRules(tile.menu)
     }
   }
-  ;(config.tiles || []).forEach(tile => sanatizeTileMenu(tile))
+  config.sections = config.sections || []
+  if (config.tiles) {
+    config.sections.unshift({ allow: true, tiles: config.tiles })
+    delete config.tiles
+  }
 
-  const kinds: (keyof FileSysconfig)[] = ['search_engines', 'calendars', 'messages', 'tiles']
+  config.sections.forEach(section => section.tiles.forEach(tile => sanatizeTileMenu(tile)))
+
+  const kinds: (keyof FileSysconfig)[] = ['search_engines', 'calendars', 'messages', 'sections']
   kinds.forEach(kind => {
     ;(config[kind] || []).forEach(entry => {
       if (typeof entry.allow === 'undefined') console.warn('Config entry', entry, 'has no "allow" attribute. It will never show up!')

--- a/src/lib/server/sysconfig/types.d.ts
+++ b/src/lib/server/sysconfig/types.d.ts
@@ -14,6 +14,7 @@ export interface Tile {
 
 export interface Section {
   title?: string
+  subtitle?: string
   tiles: Tile[]
 }
 
@@ -47,15 +48,18 @@ export interface SysconfigSection extends Section, AccessConfig {
   tiles: SysconfigTile[]
 }
 
-export interface FileSysconfig {
-  tiles: SysconfigTile[]
+interface BaseSysconfig {
   sections: SysconfigSection[]
   search_engines: (SearchEngine & AccessConfig)[]
   calendars: (Calendar & AccessConfig)[]
   messages: (Message & AccessConfig)[]
 }
 
-export interface Sysconfig extends FileSysconfig {
+export interface FileSysconfig extends BaseSysconfig {
+  tiles?: SysconfigTile[]
+}
+
+export interface Sysconfig extends BaseSysconfig {
   admin_userids: string[]
   unsplash_api_key: string | null
   openweathermap_api_key: string | null

--- a/src/lib/server/sysconfig/types.d.ts
+++ b/src/lib/server/sysconfig/types.d.ts
@@ -12,6 +12,11 @@ export interface Tile {
   }
 }
 
+export interface Section {
+  title?: string
+  tiles: Tile[]
+}
+
 export interface SearchEngine {
   title: string
   search_url: string
@@ -27,7 +32,7 @@ export interface Message {
   html: string
 }
 
-export type AccessRule = boolean | (`user:${string}` | `group:${string}` | `mail:${string}` | `email:${string}`)[]
+export type AccessRule = boolean | (`user:${string}` | `username:${string}` | `group:${string}` | `mail:${string}` | `email:${string}`)[]
 
 export interface AccessConfig {
   allow?: AccessRule
@@ -38,8 +43,13 @@ export interface SysconfigTile extends Tile, AccessConfig {
   menu?: (Tile['menu'] & { tiles: SysconfigTile[] }) & AccessConfig
 }
 
+export interface SysconfigSection extends Section, AccessConfig {
+  tiles: SysconfigTile[]
+}
+
 export interface FileSysconfig {
   tiles: SysconfigTile[]
+  sections: SysconfigSection[]
   search_engines: (SearchEngine & AccessConfig)[]
   calendars: (Calendar & AccessConfig)[]
   messages: (Message & AccessConfig)[]

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,10 +1,10 @@
-import { getUserMessages, getUserSearchEngines, getUserTiles } from '$lib/server/authz'
+import { getUserMessages, getUserSearchEngines, getUserSections } from '$lib/server/authz'
 import { queryCalendar } from '$lib/server/calendar'
 import type { PageServerLoad } from './$types'
 
 export const load: PageServerLoad = async ({ locals }) => {
   return {
-    tiles: await getUserTiles(locals.user),
+    sections: await getUserSections(locals.user),
     calendarEvents: await queryCalendar({ user: locals.user, failfast: true }), // loaded from here or /calendar/entries on timeout
     searchEngines: await getUserSearchEngines(locals.user),
     messages: await getUserMessages(locals.user)

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -38,12 +38,17 @@
     </section>
   {/if}
 
-  <div class="mt-6 flex flex-col place-content-end gap-8" class:grow={data.userConfig.tiles.position === 'bottom'}>
+  <div class="mt-6 flex flex-col place-content-end" class:grow={data.userConfig.tiles.position === 'bottom'}>
     {#each data.sections as section}
       <section class="flex flex-col justify-center">
-        {#if section.title}
-          <div class="flex flex-wrap justify-center">
-            <h2 class="text-3xl text-slate-200">{section.title}</h2>
+        {#if section.title || section.subtitle}
+          <div class="mt-6 flex flex-col items-center justify-center">
+            {#if section.title}
+              <h2 class="text-3xl text-slate-200">{section.title}</h2>
+            {/if}
+            {#if section.subtitle}
+              <h3 class="text-xl text-slate-200">{section.subtitle}</h3>
+            {/if}
           </div>
         {/if}
         <div class="flex flex-wrap justify-center" in:fly={{ y: 20 }}>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -38,11 +38,20 @@
     </section>
   {/if}
 
-  <section class="mt-6 flex items-end justify-center" class:grow={data.userConfig.tiles.position === 'bottom'}>
-    <div class="flex flex-wrap justify-center" in:fly={{ y: 20 }}>
-      {#each data.tiles as tile}
-        <Tile {...tile}></Tile>
-      {/each}
-    </div>
-  </section>
+  <div class="mt-6 flex flex-col place-content-end gap-8" class:grow={data.userConfig.tiles.position === 'bottom'}>
+    {#each data.sections as section}
+      <section class="flex flex-col justify-center">
+        {#if section.title}
+          <div class="flex flex-wrap justify-center">
+            <h2 class="text-3xl text-slate-200">{section.title}</h2>
+          </div>
+        {/if}
+        <div class="flex flex-wrap justify-center" in:fly={{ y: 20 }}>
+          {#each section.tiles || [] as tile}
+            <Tile {...tile}></Tile>
+          {/each}
+        </div>
+      </section>
+    {/each}
+  </div>
 </main>

--- a/src/routes/Tile.svelte
+++ b/src/routes/Tile.svelte
@@ -110,9 +110,9 @@ hover:from-teal-600/90 hover:via-sky-700/90 hover:to-indigo-700/90
     {/if}
   </div>
   {#if !only_icon || (!logo && !emoji)}
-    <h1 class="mt-1 overflow-hidden text-center leading-5 text-slate-300">{title || '???'}</h1>
+    <h3 class="mt-1 overflow-hidden text-center leading-5 text-slate-300">{title || '???'}</h3>
     {#if subtitle}
-      <h2 class="overflow-hidden text-center text-xs text-slate-300">{subtitle}</h2>
+      <h4 class="overflow-hidden text-center text-xs text-slate-300">{subtitle}</h4>
     {/if}
   {/if}
 </a>


### PR DESCRIPTION
I added support for `section` - groups of tiles.
See `src/lib/server/sysconfig/default.yml` for the example of the new config
The current `tiles` config option is obsolete and converts to the default first section for backward compatibility.

Example of new config entry:

```yaml
sections: # divides your tiles into sections
  - allow: true # show this section to anyone
    tiles:
      - title: Logout
        url: https://example.org/logout/
        logo: authelia # a tile can have a `logo` (image) and an `emoji` (text). Logos have precedence. At least a `logo` or an `emoji` should be present for a tile
        #allow: true # Is true by default

      - title: Hidden
        url: https://example.org
        emoji: Secret
        allow: false # always hidden

      - title: Animals
        allow: true
        menu: # tiles can have nested menus
          - title: Cats
            deny: [group:dog-lovers]
            menu:
              - title: Cat1
                emoji: 🐈
                url: https://http.cat/
              - title: Cat2
                emoji: 🐈
                url: https://http.cat/
          - title: Dogs
            deny: [group:cat-lovers]
            menu:
              - title: Dog1
                emoji: 🐶
                url: https://httpstatusdogs.com/
              - title: Dog2
                emoji: 🐶
                url: https://httpstatusdogs.com/

      - title: Sverdle
        url: /sverdle/
        allow: true
```

Example screenshot with tiles on top:

<img width="1170" alt="image" src="https://github.com/knrdl/hubleys-dashboard/assets/12608684/5cdc3971-f267-4b31-934c-ca411ddcf8a6">

Example screenshot with tiles on bottom:

<img width="1431" alt="image" src="https://github.com/knrdl/hubleys-dashboard/assets/12608684/0169dc15-b15d-4700-83f6-c296611c1362">
