### PR TITLE
feat: Add configurable data/configuration directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,9 @@ CMD ["node", "/app/entrypoint.js"]
 # one of debug, info, warn, error
 ENV LOG_LEVEL="info"
 
+# data directory path, defaults to /data if not set
+ENV DATA_DIR="/data"
+
 # userinfo headers set by the reverse proxy
 ENV HTTP_HEADER_USERID="Remote-User"
 ENV HTTP_HEADER_USERNAME="Remote-Name"

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,12 @@ CMD ["node", "/app/entrypoint.js"]
 ENV LOG_LEVEL="info"
 
 # data directory path, defaults to /data if not set
-ENV DATA_DIR="/data"
+#ENV DATA_DIR="/data"
+
+# Optional: override specific config directories
+#ENV USERS_DIR=""
+#ENV LOGOS_DIR=""
+#ENV WALLPAPER_DIR=""
 
 # userinfo headers set by the reverse proxy
 ENV HTTP_HEADER_USERID="Remote-User"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ Edit the contents of `./data/config.yml`. The default example can be found [here
 
 Fine-tuning is done via env vars defined [here](./Dockerfile#L60).
 
+### Directory Configuration
+
+The following environment variables can be used to configure the directories Hubleys stores content:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATA_DIR` | `/data` | Base directory for all data |
+| `USERS_DIR` | `$DATA_DIR/users` | Directory for user-specific data |
+| `LOGOS_DIR` | `$DATA_DIR/logos` | Directory for logo files |
+| `WALLPAPER_DIR` | `$DATA_DIR/wallpaper` | Directory for wallpaper files |
+
+If the specific directory variables (`USERS_DIR`, `LOGOS_DIR`, `WALLPAPER_DIR`) are not set, they will default to subdirectories under `DATA_DIR`. This allows you to:
+- Keep everything under one base directory (default behavior)
+- Mount specific directories in different locations
+- Use different volumes for different types of data
+
 ## 3. Configure reverse proxy + auth provider
 
 Hubleys uses forward auth (also known as webproxy auth) to get all relevant user info via http header:

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,6 +4,7 @@ import { getUserConfig, initDefaultUserConfig, runUserConfigMigrations } from '$
 import fs from 'fs'
 import { isFile } from '$lib/server/fs'
 import type { RequestUserInfo } from '$lib/server/types'
+import { DATA_DIR, PATHS } from '$lib/server/config'
 
 function getConfiguredUserLang(ev: RequestEvent) {
   if (ev.locals.userConfig.language === null) return (ev.request.headers.get('accept-language') || 'en').split(/[,;]/)[0]
@@ -71,17 +72,17 @@ function applyLogLevels() {
 
 async function onServerStartup() {
   try {
-    await fs.promises.access('/data', fs.constants.W_OK)
+    await fs.promises.access(DATA_DIR, fs.constants.W_OK)
   } catch (_) {
-    console.log('Missing write permission to the /data volume. The folder must be writable by the user with uid=1000.')
+    console.log(`Missing write permission to the ${DATA_DIR} volume. The folder must be writable by the user with uid=1000.`)
     process.exit(1)
   }
   await Promise.all([
-    fs.promises.mkdir('/data/logos', { recursive: true }),
-    fs.promises.mkdir('/data/users/backgrounds', { recursive: true }),
-    fs.promises.mkdir('/data/users/config', { recursive: true }),
+    fs.promises.mkdir(PATHS.LOGOS, { recursive: true }),
+    fs.promises.mkdir(PATHS.USERS.BACKGROUNDS, { recursive: true }),
+    fs.promises.mkdir(PATHS.USERS.CONFIG, { recursive: true }),
     (async () => {
-      if (await isFile('/data/favicon.png')) await fs.promises.copyFile('/data/favicon.png', '/app/client/favicon.png')
+      if (await isFile(PATHS.FAVICON)) await fs.promises.copyFile(PATHS.FAVICON, '/app/client/favicon.png')
     })()
   ])
 

--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -1,0 +1,23 @@
+import { env } from '$env/dynamic/private'
+import path from 'node:path'
+
+// Default to /data if DATA_DIR is not set
+export const DATA_DIR = env.DATA_DIR || '/data'
+
+// Helper functions to get paths within the data directory
+export function getDataPath(...parts: string[]): string {
+  return path.join(DATA_DIR, ...parts)
+}
+
+// Common paths used throughout the application
+export const PATHS = {
+  CONFIG: getDataPath('config.yml'),
+  LOGOS: getDataPath('logos'),
+  WALLPAPER: getDataPath('wallpaper'),
+  USERS: {
+    BACKGROUNDS: getDataPath('users', 'backgrounds'),
+    CONFIG: getDataPath('users', 'config'),
+    DEFAULT_CONFIG: getDataPath('users', 'default-config.json')
+  },
+  FAVICON: getDataPath('favicon.png')
+}

--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -1,23 +1,24 @@
 import { env } from '$env/dynamic/private'
 import path from 'node:path'
 
-// Default to /data if DATA_DIR is not set
+// Base data directory configuration
 export const DATA_DIR = env.DATA_DIR || '/data'
 
-// Helper functions to get paths within the data directory
-export function getDataPath(...parts: string[]): string {
-  return path.join(DATA_DIR, ...parts)
-}
+// Individual directory configurations
+// If not set, they will be subdirectories under DATA_DIR
+export const USERS_DIR = env.USERS_DIR || path.join(DATA_DIR, 'users')
+export const LOGOS_DIR = env.LOGOS_DIR || path.join(DATA_DIR, 'logos')
+export const WALLPAPER_DIR = env.WALLPAPER_DIR || path.join(DATA_DIR, 'wallpaper')
 
 // Common paths used throughout the application
 export const PATHS = {
-  CONFIG: getDataPath('config.yml'),
-  LOGOS: getDataPath('logos'),
-  WALLPAPER: getDataPath('wallpaper'),
+  CONFIG: path.join(DATA_DIR, 'config.yml'),
+  LOGOS: LOGOS_DIR,
+  WALLPAPER: WALLPAPER_DIR,
   USERS: {
-    BACKGROUNDS: getDataPath('users', 'backgrounds'),
-    CONFIG: getDataPath('users', 'config'),
-    DEFAULT_CONFIG: getDataPath('users', 'default-config.json')
+    BACKGROUNDS: path.join(USERS_DIR, 'backgrounds'),
+    CONFIG: path.join(USERS_DIR, 'config'),
+    DEFAULT_CONFIG: path.join(USERS_DIR, 'default-config.json')
   },
-  FAVICON: getDataPath('favicon.png')
+  FAVICON: path.join(DATA_DIR, 'favicon.png')
 }

--- a/src/lib/server/sysconfig/index.ts
+++ b/src/lib/server/sysconfig/index.ts
@@ -4,6 +4,7 @@ import { PUBLIC_BUILD_DATE, PUBLIC_VERSION } from '$env/static/public'
 import { isFile } from '$lib/server/fs'
 import fs from 'fs'
 import type { FileSysconfig, Sysconfig, SysconfigSection, SysconfigTile } from './types'
+import { PATHS } from '$lib/server/config'
 
 export let sysConfig: Sysconfig
 
@@ -80,14 +81,12 @@ function sanitizeFileConfig(config: FileSysconfig) {
 }
 
 async function loadConfig(): Promise<Sysconfig> {
-  const configpath = '/data/config.yml'
-
-  if (!(await isFile(configpath))) {
+  if (!(await isFile(PATHS.CONFIG))) {
     const body = (await import('./default.yml?raw')).default
-    await fs.promises.writeFile(configpath, body, { encoding: 'utf8' })
+    await fs.promises.writeFile(PATHS.CONFIG, body, { encoding: 'utf8' })
   }
 
-  const configFile = await fs.promises.readFile(configpath, { encoding: 'utf8' })
+  const configFile = await fs.promises.readFile(PATHS.CONFIG, { encoding: 'utf8' })
   const config = yaml.load(configFile) as FileSysconfig
   sanitizeFileConfig(config)
 

--- a/src/lib/server/userconfig/index.ts
+++ b/src/lib/server/userconfig/index.ts
@@ -2,6 +2,7 @@ import { isFile, readJsonFile, writeJsonFile } from '$lib/server/fs'
 import path from 'node:path'
 import type { UserConfig } from './types'
 import { opendir } from 'node:fs/promises'
+import { PATHS } from '$lib/server/config'
 
 let defaultConfig: UserConfig = (await import('./default.json')).default as UserConfig
 
@@ -11,7 +12,7 @@ let _cache: Record<UserId, UserConfig> = {}
 
 function userConfigFilePath(userid: UserId) {
   const encUserid = encodeURIComponent(userid)
-  return '/data/users/config/' + encUserid + '.json'
+  return path.join(PATHS.USERS.CONFIG, encUserid + '.json')
 }
 
 async function readUserConfig(userid: UserId) {
@@ -43,18 +44,17 @@ export async function reloadAllUsersConfig() {
 }
 
 export function userBackgroundImgFilePath(imgId: string) {
-  return path.join('/data/users/backgrounds/', path.basename(imgId))
+  return path.join(PATHS.USERS.BACKGROUNDS, path.basename(imgId))
 }
 
 export async function initDefaultUserConfig() {
-  const path = '/data/users/default-config.json'
-  if (await isFile(path)) defaultConfig = await readJsonFile(path)
-  else await writeJsonFile(path, defaultConfig)
+  if (await isFile(PATHS.USERS.DEFAULT_CONFIG)) defaultConfig = await readJsonFile(PATHS.USERS.DEFAULT_CONFIG)
+  else await writeJsonFile(PATHS.USERS.DEFAULT_CONFIG, defaultConfig)
 }
 
 export async function runUserConfigMigrations() {
   const newest_migration_version = 2
-  for await (const e of await opendir('/data/users/config/')) {
+  for await (const e of await opendir(PATHS.USERS.CONFIG)) {
     if (e.isFile() && e.name.endsWith('.json')) {
       const p = path.join(e.parentPath, e.name)
       const profile = await readJsonFile<UserConfig>(p)

--- a/src/routes/background/wallpaper/[...wallpaper]/+server.ts
+++ b/src/routes/background/wallpaper/[...wallpaper]/+server.ts
@@ -3,12 +3,13 @@ import { lookup } from 'mrmime'
 import { isFile } from '$lib/server/fs'
 import { error } from '@sveltejs/kit'
 import path from 'node:path'
+import { PATHS } from '$lib/server/config'
 
 export async function GET({ params, locals }) {
   const bgCfg = locals.userConfig.backgrounds[0]
   if (bgCfg.background === 'random' && bgCfg.random_image.provider === 'local') {
-    const p = path.join('/data/wallpaper/', path.normalize(params.wallpaper))
-    if (p.startsWith('/data/wallpaper/')) {
+    const p = path.join(PATHS.WALLPAPER, path.normalize(params.wallpaper))
+    if (p.startsWith(PATHS.WALLPAPER)) {
       if (await isFile(p))
         return new Response(fs.createReadStream(p) as unknown as ReadableStream, {
           headers: { 'Content-Type': lookup(params.wallpaper) || 'application/octet-stream' }

--- a/src/routes/healthcheck/+server.ts
+++ b/src/routes/healthcheck/+server.ts
@@ -1,15 +1,16 @@
 import { error, json, type RequestHandler } from '@sveltejs/kit'
 import { statfs, access } from 'fs/promises'
 import fs from 'fs'
+import { DATA_DIR } from '$lib/server/config'
 
 export const GET: RequestHandler = async () => {
   try {
-    await access('/data', fs.constants.W_OK)
+    await access(DATA_DIR, fs.constants.W_OK)
   } catch (_) {
     error(500, 'data directory is not writable')
   }
 
-  const stats = await statfs('/data')
+  const stats = await statfs(DATA_DIR)
   if (stats.bavail * stats.bsize < 25 * 1024 ** 2) error(500, 'less than 25 MiB storage available')
 
   return json('ok')

--- a/src/routes/logo/[slug]/+server.ts
+++ b/src/routes/logo/[slug]/+server.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs'
 import { opendir } from 'node:fs/promises'
 import path from 'node:path'
 import { lookup } from 'mrmime'
+import { PATHS } from '$lib/server/config'
 
 async function getFilename({ fspath, filename, uapath }: { fspath: string; filename: string; uapath?: string }) {
   try {
@@ -19,7 +20,7 @@ async function getFilename({ fspath, filename, uapath }: { fspath: string; filen
 export async function GET({ params }) {
   const filename = path.basename(params.slug)
 
-  const job1 = getFilename({ fspath: '/data/logos/', filename })
+  const job1 = getFilename({ fspath: PATHS.LOGOS, filename })
   const job2 = getFilename({ fspath: dev ? 'static/fallback-logos' : 'client/fallback-logos', uapath: '/fallback-logos', filename })
 
   const path1 = await job1


### PR DESCRIPTION
This PR replaces hard coded directory paths with the DATA_DIR environment variable, allowing the data directory location to be customised. If DATA_DIR is not set, it defaults to /data to maintain backward compatibility.

It also allows setting USERS_DIR, LOGOS_DIR and WALLPAPER_DIR, if you wish to store them in separate locations.