### PR TITLE
Fix: Prevent horizontal scrolling caused by vertical scrollbar

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -20,6 +20,13 @@
   }
 }
 
+/* Prevent horizontal scrollbar caused by vertical scrollbar offset */
+@layer base {
+  html, body {
+    overflow-x: hidden;
+  }
+}
+
 :root {
   font-family:
     Arial,


### PR DESCRIPTION
Small CSS fix to prevent a horizontal scrollbar from appearing when the page has enough content to be vertically scrollable.

Since the dashboard is designed and structured in a way that horizontal scrolling should never be necessary, I expect this change to be non-invasive.