### PR TITLE
support google autocomplete (client=firefox)

### DIFF
--- a/src/routes/search/+server.ts
+++ b/src/routes/search/+server.ts
@@ -33,6 +33,8 @@ export async function GET({ url, locals }) {
     return json(resbody.map(res => res.phrase))
   } else if (Array.isArray(resbody) && resbody.every(item => typeof item === 'string')) {
     return json(resbody)
+  } else if (Array.isArray(resbody) && resbody.length === 4 && Array.isArray(resbody[1]) && resbody[1].every(item => typeof item === 'string'))
+    return json(resbody[1])
   } else {
     error(500, 'search provider response format not implemented')
   }


### PR DESCRIPTION
This change adds support for google autocomplete using the following autocomplete URL:

http://www.google.com/complete/search?client=firefox

I haven't tested this as I've not done any node development in the past and not sure how to get a dev environment up and running.

The 'client=firefox' is required as google requires the client field and the response changes based on the client specificed.  'firefox' looked to be the least complicated response, so I chose that.  I know that firefox, chrome, and safari all are supported and get a unique response.  Here is that a test query/response looks like for all 3 in case you want to investigate further:

http://www.google.com/complete/search?client=firefox&q=test ["test",["test","testosterone","testicular torsion","test internet speed","testament of ann lee","test my internet speed","testosterone booster","testosterone injections","testicular cancer","testosterone replacement therapy"],[],{"google:suggestsubtypes":[[512,433,131],[512,433],[512,433],[512,433,131],[512,650,433,131],[512],[512,433],[512],[512,433],[512,433]]}]

http://www.google.com/complete/search?client=safari&q=test ["test",[["test","",[512,433,131]],["testosterone","",[512,433]],["testicular torsion","",[512,433]],["test internet speed","",[512,433,131]],["testament of ann lee","",[512,433,131,650]],["test my internet speed","",[512]],["testosterone booster","",[512,433]],["testosterone injections","",[512]],["testicular cancer","",[512,433]],["testosterone replacement therapy","",[512,433]]],{"k":1,"q":"hywjPg1zYV0diWb5Xd1lrTm1JTY"}]

http://www.google.com/complete/search?client=chrome&q=test ["test",["testosterone","testicular torsion","test internet speed","testament of ann lee","test my internet speed","testosterone booster","testosterone injections","testicular cancer","testosterone replacement therapy","testament","testerup","test my speed","testosterone cypionate","testosterone test","testicular cancer symptoms"],["","","","","","","","","","","","","","",""],[],{"google:clientdata":{"bpc":false,"tlw":false},"google:suggestrelevance":[601,600,562,561,560,559,558,557,556,555,554,553,552,551,550],"google:suggestsubtypes":[[512,433],[512,433],[512,433,131],[512,650,433,131],[512],[512,433],[512],[512,433],[512,433],[512,433],[512],[512,433,131],[512,433],[512,433],[512,433]],"google:suggesttype":["QUERY","QUERY","QUERY","QUERY","QUERY","QUERY","QUERY","QUERY","QUERY","QUERY","QUERY","QUERY","QUERY","QUERY","QUERY"],"google:verbatimrelevance":1300}]